### PR TITLE
fix compile error --- xyz.coolblog.model does not exist

### DIFF
--- a/src/main/java/xyz/coolblog/mybatis/ArticleTypeHandler.java
+++ b/src/main/java/xyz/coolblog/mybatis/ArticleTypeHandler.java
@@ -8,7 +8,6 @@ import org.apache.ibatis.type.BaseTypeHandler;
 import org.apache.ibatis.type.JdbcType;
 import org.apache.ibatis.type.MappedTypes;
 import xyz.coolblog.constant.ArticleTypeEnum;
-import xyz.coolblog.model.Article;
 
 /**
  * ArticleTypeHandler


### PR DESCRIPTION
xyz.coolblog.model.Article不存在，ArticleTypeHandler.java也没有使用Article，可以删除。